### PR TITLE
set prevScale = scale when initializing

### DIFF
--- a/VSProject/KSPWheel/PartModules/KSPWheelBase.cs
+++ b/VSProject/KSPWheel/PartModules/KSPWheelBase.cs
@@ -773,6 +773,7 @@ namespace KSPWheel
         private void initializeScaling()
         {
             if (initializedScaling) { return; }
+            prevScale = scale;
             initializedScaling = true;
             setScale(scale, false);
         }


### PR DESCRIPTION
Sets prevScale to scale in initializeScaling().
Fixes an issue where attach nodes get scaled incorrectly when loading a craft file. (possibly also when loading a vessel in the flight scene?)
Issue is caused because prevScale defaults to 1 and through division by prevScale and multiplication by newScale, the node gets moved. This problem has apparently caused wheel instability. (I was not able to repro the instability but other players have and report that this change fixed the problem for them)

Will not fix existing craft; craft files must be edited and fixed